### PR TITLE
レシピ登録画面の料理の画像登録ボタン追加とレイアウト修正しました。

### DIFF
--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -23,29 +23,56 @@ body {
     width: 100%;
     position: fixed;
     top: 0px;
-
 }
 .random-button button {
     font-size :24px;
+
 }
 .random-button {
     text-align:center;
+    margin:50px;
 }
 .select-meal {
     text-align:center;
+    margin:50px;
 }
 .meal-register {
     text-align:center;
 }
+label {
+    padding: 10px 40px;
+    color: #ffffff;
+    background-color:#E5E5E5;
+    cursor: pointer;
+}
+.sentaku {
+display: none;
+}
+
 .meals-list {
     text-align:center;
+    margin:50px;
 }
 .meal-detail {
     text-align:center;
+    margin:50px;
 }
 .categoly-list {
     text-align:center;
+    margin:50px;
 }
 .categoly-create {
     text-align:center;
+    margin:50px;
 }
+.postBtn{
+    position: relative;
+    top:6px;
+    box-shadow:none;
+    margin:50px;
+    background-color:;
+    width : 150px;
+    height: 50px;
+    font-weight: bold;
+}
+

--- a/src/resources/views/meals/create.blade.php
+++ b/src/resources/views/meals/create.blade.php
@@ -49,12 +49,14 @@
               <input type="number"placeholder="500円"name='コスト'>
             </div>
 
-            <!--<div class="meal-categoly">
-              <h2>カテゴリー</h2>
-              <select class="select-categoly">
-                <option>選択してください</option>
-            　</select>
-            </div>-->
+            <!--
+                <div class="meal-categoly">
+                    <h2>カテゴリー</h2>
+                    <select class="select-categoly">
+                        <option>選択してください</option>
+            　       </select>
+                </div>
+             -->
 
             <div clas="meal-diffyculty">
               <h2>難易度</h2>

--- a/src/resources/views/meals/create.blade.php
+++ b/src/resources/views/meals/create.blade.php
@@ -20,48 +20,58 @@
           <form action="/register"method="POST"id='form'>
             <h1>料理登録</h1>
             <div class="meal-name">
+               <h2>写真を登録する</h2>
+               <div style="text-align:center">
+                <form action="index.php" method="post" enctype="multipart/form-data" >
+                <label><input class="sentaku" type="file" name="image" accept="image/*" >写真を選択</label>
+                <br>
+                <br>
+                <input type="submit" value="送信">
+                </div>
+
+
               <h2>料理名</h2>
               <input type="text"placeholder="オムライス"name="名前">
             </div>
-            
+
             <div class="meal-Ingredients_Memo">
               <h2>材料メモ</h2>
-              <input type="text"placeholder="卵二個、牛乳"name="メモ">
+              <textarea  type="text"placeholder="・卵二個・牛乳"name="メモ"></textarea>
             </div>
-            
+
             <div class="meal-way">
               <h2>作り方</h2>
               <input type="text"placeholder="卵を割って～～～"name='作り方'>
             </div>
-            
+
             <div class="meal-cost">
               <h2>コスト</h2>
-              <input type="number"placeholder="500"name='コスト'>円
-            </div>  
-            
-            <div class="meal-categoly">
+              <input type="number"placeholder="500円"name='コスト'>
+            </div>
+
+            <!--<div class="meal-categoly">
               <h2>カテゴリー</h2>
               <select class="select-categoly">
                 <option>選択してください</option>
-            　</select>                
-            </div>
-            
+            　</select>
+            </div>-->
+
             <div clas="meal-diffyculty">
               <h2>難易度</h2>
-              <input type="radio"name="難易度" value=1 checked> レベル1
-              <input type="radio" name="難易度"  value=2> レベル２
-              <input type="radio" name="難易度" value=3> レベル3
+              <input type="radio"name="難易度"value=1 checked> レベル1
+              <input type="radio"name="難易度"value=2> レベル２
+              <input type="radio"name="難易度"value=3> レベル3
             </div>
-            
+
             <div class="meal-satiety">
               <h2>満腹度</h2>
-              <input type="radio"name="満足度" value=1 checked> ちょっと食べたい
-              <input type="radio"  name="満足度"value=2> ちょうどいい
-              <input type="radio"name="満足度" value=3> がっつり
+              <input type="radio"name="満足度"value=1 checked> ちょっと食べたい
+              <input type="radio"name="満足度"value=2> ちょうどいい
+              <input type="radio"name="満足度"value=3> がっつり
 
             </div>
-            
-            <input type="button" value="登録する" class="postBtn"id="meal_create">  
+
+            <input type="button" value="登録する" class="postBtn"id="meal_create">
           </form>
         </div>
       </div>

--- a/src/resources/views/meals/create.blade.php
+++ b/src/resources/views/meals/create.blade.php
@@ -49,15 +49,6 @@
               <input type="number"placeholder="500円"name='コスト'>
             </div>
 
-            <!--
-                <div class="meal-categoly">
-                    <h2>カテゴリー</h2>
-                    <select class="select-categoly">
-                        <option>選択してください</option>
-            　       </select>
-                </div>
-             -->
-
             <div clas="meal-diffyculty">
               <h2>難易度</h2>
               <input type="radio"name="難易度"value=1 checked> レベル1

--- a/src/resources/views/meals/show.blade.php
+++ b/src/resources/views/meals/show.blade.php
@@ -28,9 +28,9 @@
            <p>{{$meal->name}}</p>
           </div>
 
-          <textarea class="meal-Ingredients_Memo">
+          <div class="meal-Ingredients_Memo">
             <h2>材料メモ</h2>
-          </textarea>
+          </div>
 
             <div class="meal-way">
               <h2>作り方</h2>

--- a/src/resources/views/meals/show.blade.php
+++ b/src/resources/views/meals/show.blade.php
@@ -21,40 +21,40 @@
         　<form action='/'id='' method="post" style="display:inline">
             @csrf
             @method('DELETE')
-            <button type="submit">消去</button> 
+            <button type="submit">消去</button>
         　</form>
     　     <div class="meal-name">
            <h2>料理名</h2>
            <p>{{$meal->name}}</p>
           </div>
-            
-          <div class="meal-Ingredients_Memo">
+
+          <textarea class="meal-Ingredients_Memo">
             <h2>材料メモ</h2>
-          </div>
-            
+          </textarea>
+
             <div class="meal-way">
               <h2>作り方</h2>
             </div>
-    
+
             <div class="meal-cost">
               <h2>コスト</h2>
-            </div>  
-            
-            <div class="meal-categoly">
-              <h2>カテゴリー</h2>
             </div>
-            
-            <div clas="meal-diffyculty">
+
+            <!--<div class="meal-categoly">
+              <h2>カテゴリー</h2>
+            </div>-->
+
+            <div class="meal-diffyculty">
               <h2>難易度</h2>
             </div>
-            
+
             <div class="meal-satiety">
               <h2>満腹度</h2>
-            </div>  
+            </div>
     　  </div>
       </div>
       <div class="footer">
-          
+
       </div>
     </body>
 </html>


### PR DESCRIPTION
①写真を登録するボタン追加
②材料メモのテキストボックス→テキストエリアに変更
③コストの欄外の”円”をテキストエリア内に記載
実施理由
”円”がテキストエリア外だとテキストボックスが中央揃いにならない為。
④登録するボタンの大きさ変更